### PR TITLE
2 Check `spawnSync` safety in build/bin/all.js

### DIFF
--- a/build/bin/all.js
+++ b/build/bin/all.js
@@ -4,7 +4,7 @@
 // @ts-check
 
 const path = require('path');
-const child_process = require('child_process');
+const childProcess = require('child_process');
 
 const root = path.dirname(path.dirname(__dirname));
 const args = process.argv.slice(2);
@@ -20,6 +20,10 @@ const script = args[0] === 'run' ? args[1] : args[0];
 for (const elem of folders.map(item => { return { folder: item.folder, scripts: new Set(item.scripts) }; })) {
     if (elem.scripts.has(script)) {
         console.log(path.join(root, elem.folder));
-        child_process.spawnSync(`npm ${args.join(' ')}`, { cwd: path.join(root, elem.folder), shell: true, stdio: 'inherit' });
+        childProcess.spawnSync(`npm ${args.join(' ')}`, {
+            cwd: path.join(root, elem.folder),
+            shell: true,
+            stdio: 'inherit'
+        });
     }
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pikesies-client",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "pikesies-client",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "dependencies": {
                 "vscode-languageclient": "^7.0.0"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pikesies",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pikesies",
-			"version": "1.0.0",
+			"version": "1.1.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pikesies-lsp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pikesies-lsp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "vscode-languageserver": "^7.0.0",
         "vscode-uri": "^3.0.2"


### PR DESCRIPTION
Checked reported Security Hotspot.
Script is limited to allow either `install` or `lint` actions, which are both fine.
Includes small formatting to aid in readability.